### PR TITLE
Fix bash syntax in sage -upgrade

### DIFF
--- a/src/bin/sage-upgrade
+++ b/src/bin/sage-upgrade
@@ -26,13 +26,17 @@ if [ "$#" -gt 0 ]; then
     BRANCH="$1"
     shift
 else
-    BRANCH=$(git symbolic-ref HEAD || git describe --exact-match --tags HEAD | { read tag; echo refs/tags/$tag })
-    case $BRANCH in
-        refs/heads/master) BRANCH=master;;
-        refs/heads/release) BRANCH=release;;
-        refs/heads/beta) BRANCH=beta;;
-        refs/tags/*) BRANCH=release;;
-    esac
+    BRANCH=$(git symbolic-ref HEAD) ||
+        BRANCH=$(git describe --exact-match --tags HEAD | \
+                 sed -e 's;^;refs/tags/;')
+    if [ -n "$BRANCH" ]; then
+        case $BRANCH in
+            refs/heads/master) BRANCH=master;;
+            refs/heads/release) BRANCH=release;;
+            refs/heads/beta) BRANCH=beta;;
+            refs/tags/*) BRANCH=release;;
+        esac
+    fi
 fi
 
 if [ -z "$BRANCH" ]; then


### PR DESCRIPTION
Trying to run `./sage -upgrade` in 5.9rc0 results in the following:

```
~/Installations/sage-5.9.rc0» ./sage -upgrade
/home/punarbasu/Installations/sage-5.9.rc0/src/bin/sage-upgrade: command substitution: line 30: syntax error near unexpected token `)'
```

This pull request fixes this.
