### PR TITLE
Fix trac link in partition.py

### DIFF
--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -4770,7 +4770,7 @@ class Partitions(UniqueRepresentation, Parent):
         sage: Partitions(max_part = 3)
         3-Bounded Partitions
 
-    Check that trac:`14145` has been fixed::
+    Check that :trac:`14145` has been fixed::
 
         sage: 1 in Partitions()
         False


### PR DESCRIPTION
Needed to add a colon for a Trac reference in the Partitions documentation
