### PR TITLE
let cvxopt correctly install spkg docs

### DIFF
--- a/build/pkgs/cvxopt/spkg-install
+++ b/build/pkgs/cvxopt/spkg-install
@@ -58,6 +58,6 @@ if [ "x$SAGE_SPKG_INSTALL_DOCS" = xyes ] ; then
       rm -rf $SAGE_LOCAL/share/doc/cvxopt/html
    fi
    mkdir -p $SAGE_LOCAL/share/doc/cvxopt/html
-   cp -r build/html/* $SAGE_LOCAL/share/doc/cvxopt/html/
+   cp -r html/* $SAGE_LOCAL/share/doc/cvxopt/html/
 fi
 


### PR DESCRIPTION
According to a bug report, 

> When installing cvxopt with the environment variable SAGE_SPKG_INSTALL_DOCS set to "yes", the install fails. This is due to a bug in spkg-install. On the last-but-one line of that file, it attempts to copy the docs from build/html to the install directory; however, the (pre-built) docs are in html/, not in build/html/. Changing this line fixes the bug.
