### PR TITLE
fix NameError in mathematica_free integration

### DIFF
--- a/src/sage/symbolic/integration/external.py
+++ b/src/sage/symbolic/integration/external.py
@@ -55,7 +55,7 @@ def mma_free_integrator(expression, v, a=None, b=None):
             if chr(i) not in vars:
                 shadow_x = SR.var(chr(i))
                 break
-        expression = expression.subs({x:shadow_x}).subs({dvar: x})
+        expression = expression.subs({x:shadow_x}).subs({v: x})
     params = urllib.urlencode({'expr': expression._mathematica_init_(), 'random': 'false'})
     page = urllib.urlopen("http://integrals.wolfram.com/index.jsp", params).read()
     page = page[page.index('"inputForm"'):page.index('"outputForm"')]


### PR DESCRIPTION
It seems like the purpose was to normalize the variable of integration to `x`.

The line in question substitutes x for `dvar` rather than the variable of integration passed in, `v`.
