### PR TITLE
Fix in PolynomialSequence

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -333,7 +333,7 @@ def PolynomialSequence(arg1, arg2=None, immutable=False, cr=False, cr_str=None):
     # make sure we use the polynomial ring as ring not the monoid
     ring = (ring(1) + ring(1)).parent()
 
-    if c != 2:
+    if c != 2 or not K.is_finite():
         return PolynomialSequence_generic(parts, ring, immutable=immutable, cr=cr, cr_str=cr_str)
     elif K.degree() == 1:
         return PolynomialSequence_gf2(parts, ring, immutable=immutable, cr=cr, cr_str=cr_str)


### PR DESCRIPTION
The code

```
F = GF(2)
L.<t> = PowerSeriesRing(F,'t')
R.<x,y> = PolynomialRing(L,'x,y')
PolynomialSequence([0], R)
```

does not work because PolynomialSequence makes an implicit distinction between fields of characteristic != 2 and finite fields of characteristic 2. The fix allows for infinite fields of characteristic 2 (treating them generically together with fields of characteristic != 2).
