### PR TITLE
Fix containment.

### DIFF
--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -1304,7 +1304,7 @@ cdef class Parent(category_object.CategoryObject):
                     # comparisons.
                     return True
                 return False
-        except (TypeError, ValueError, ZeroDivisionError):
+        except (TypeError, ValueError, ZeroDivisionError, ArithmeticError):
             return False
 
     cpdef coerce(self, x):


### PR DESCRIPTION
Containment testing catches TypeError, ValueError, ZeroDivisionError.
However, casting a Laurent series to a power series (when it isn't one)
raises an ArithmeticError. This commit adds ArithmeticError to the list
to make the following code work:

L.<t> = LaurentSeriesRing(GF(2))
R.<x,y> = PolynomialRing(L)
O = L.power_series_ring()
S.<x,y> = PolynomialRing(O)
t*_(-1)_x*y in S
