### PR TITLE
fixing typo in the doc - wrong module name

### DIFF
--- a/src/sage/geometry/hyperplane_arrangement/arrangement.py
+++ b/src/sage/geometry/hyperplane_arrangement/arrangement.py
@@ -1935,7 +1935,7 @@ class HyperplaneArrangements(Parent, UniqueRepresentation):
     Hyperplane arrangements.
 
     For more information on hyperplane arrangements, see
-    :mod:`sage.geometry.hyperplane_arrangements.arrangement`.
+    :mod:`sage.geometry.hyperplane_arrangement.arrangement`.
 
     INPUT:
 


### PR DESCRIPTION
the subject says it all
