### PR TITLE
Update Python development link

### DIFF
--- a/src/doc/en/tutorial/bibliography.rst
+++ b/src/doc/en/tutorial/bibliography.rst
@@ -31,9 +31,8 @@ Bibliography
 ..  [Py] The Python language http://www.python.org/
     Reference Manual http://docs.python.org/ref/ref.html.
 
-..  [PyDev] Guido, Some Guys, and a Mailing List: How Python is
-    Developed,
-    http://www.python.org/dev/dev_intro.html.
+..  [PyDev] Python Developer's Guide,
+    https://docs.python.org/devguide/.
 
 ..  [Pyr] Pyrex,
     http://www.cosc.canterbury.ac.nz/~greg/python/Pyrex/.


### PR DESCRIPTION
Currently linked document disappeared from their site at the end of 2007:

http://web.archive.org/web/20071212021645/http://www.python.org/dev/dev_intro.html
http://web.archive.org/web/20080219151500/http://www.python.org/dev/dev_intro.html
