### PR TITLE
Two minor spelling fixes to vertex_separation.pyx

### DIFF
--- a/src/sage/graphs/graph_decompositions/vertex_separation.pyx
+++ b/src/sage/graphs/graph_decompositions/vertex_separation.pyx
@@ -96,7 +96,7 @@ knows that having `S` in a sequence means a total cost of at least `c'(S) +
 5`. For this reason, for each set `S` we store the value of `c'(S)`, and replace
 it by `\max (c'(S), \min_{\text{next}})` (where `\min_{\text{next}}` is the
 minimum of the costs of the out-neighbors of `S`) once the costs of these
-out-neighbors have been evaluated by the algrithm.
+out-neighbors have been evaluated by the algorithm.
 
 .. NOTE::
 
@@ -874,7 +874,7 @@ def is_valid_ordering(G, L):
     OUTPUT:
 
     Returns ``True`` if `L` is a valid vertex ordering for `G`, and ``False``
-    oterwise.
+    otherwise.
 
 
     EXAMPLE:


### PR DESCRIPTION
Fixed the spelling of "algorithm" and "otherwise"
