### PR TITLE
Changed the plot method of FreeModuleElement class to use arrow instead

### DIFF
--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -2297,27 +2297,20 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         else:
             start = list(start)
 
-
-        if plot_type == 'arrow' or plot_type == 'point':
+        if plot_type != 'step':
             dimension = len(coords)
-            if dimension == 3:
-                from sage.plot.plot3d.shapes2 import line3d, point3d
+            if dimension < 2:
+                # pad to make 2-dimensional
+                coords.extend([0]*(2-dimension))
+                start.extend([0]*(2-dimension))
+            
+            if plot_type == 'arrow':
+                from sage.plot.all import arrow
+                return arrow(start, [(u+v) for u,v in zip(coords, start)], **kwds)
+            elif plot_type == 'point':
+                from sage.plot.all import point
+                return point(coords, **kwds)
 
-                if plot_type == 'arrow':
-                    return line3d([start, [(u+v) for u,v in zip(coords, start)]], arrow_head=True, **kwds)
-                else:
-                    return point3d(coords, **kwds)
-            elif dimension < 3:
-                if dimension < 2:
-                    # pad to make 2-dimensional
-                    coords.extend([0]*(2-dimension))
-                    start.extend([0]*(2-dimension))
-
-                from sage.plot.all import arrow, point
-                if plot_type == 'arrow':
-                    return arrow(start, [(u+v) for u,v in zip(coords, start)], **kwds)
-                else:
-                    return point(coords, **kwds)
             else:
                 raise ValueError("arrow and point plots require vectors with 3 or fewer components")
 


### PR DESCRIPTION
of line3d.

I had issues with the 3d representation of vectors within vector fields
being unclear as to where the actual arrow head was, as well as, where
the tail was.  Also, to me it makes sense to just use arrow rather than
line3d which also allows more control over the appearance of the
vectors.  Jmol takes noticeably longer to generate the graph, however, it still doesn't take that long
but I suspect that's more of an issue with how arrow's jmol representation is handled.  Anyways, I think the change makes 3d vectors look better.
