### PR TITLE
[Manifolds] Better error message for non-existing chart conversion

### DIFF
--- a/src/sage/manifolds/scalarfield.py
+++ b/src/sage/manifolds/scalarfield.py
@@ -1063,7 +1063,7 @@ class ScalarField(CommutativeAlgebraElement):
                 if not found:
                     raise ValueError("no starting chart could be found to " +
                                      "compute the expression in the {}".format(chart))
-            change = self._domain._coord_changes[(chart, from_chart)]
+            change = self._domain.coord_changes(chart, from_chart)
             # old coordinates expressed in terms of the new ones:
             coords = [ change._transf._functions[i]._express
                        for i in range(self._manifold.dim()) ]


### PR DESCRIPTION
If a transition map between charts was needed but was not defined then a `KeyError` was thrown. With this fix the more informative message ("Chart from XYZ to ZY not defined") is shown.
