### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cygwin-minimal.yml
+++ b/.github/workflows/ci-cygwin-minimal.yml
@@ -16,6 +16,9 @@ env:
   EXTRA_CONFIGURE_ARGS: --enable-fat-binary
   SAGE_LOCAL: /opt/sage-${{ github.sha }}
 
+permissions:
+  contents: read
+
 jobs:
 
 ############################################## stage-i ##########################################

--- a/.github/workflows/ci-cygwin-standard.yml
+++ b/.github/workflows/ci-cygwin-standard.yml
@@ -16,6 +16,9 @@ env:
   EXTRA_CONFIGURE_ARGS: --enable-fat-binary
   SAGE_LOCAL: /opt/sage-${{ github.sha }}
 
+permissions:
+  contents: read
+
 jobs:
 
 ############################################## stage-i ##########################################

--- a/.github/workflows/ci-wsl.yml
+++ b/.github/workflows/ci-wsl.yml
@@ -11,6 +11,9 @@ on:
   workflow_dispatch:
     # Allow to run manually
 
+permissions:
+  contents: read
+
 jobs:
   windows:
     runs-on: windows-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-pycodestyle:
     name: Code style check with pycodestyle

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -14,6 +14,9 @@ on:
   workflow_dispatch:
     # Allow to run manually
 
+permissions:
+  contents: read
+
 jobs:
 
   release_dist:

--- a/.github/workflows/ticket.yaml
+++ b/.github/workflows/ticket.yaml
@@ -10,6 +10,9 @@ on:
       - 'ticket/**'
 
 
+permissions:
+  contents: read
+
 jobs:
   ticket_ci:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>


<a href="https://gitpod.io/#https://github.com/sagemath/sage/pull/106"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

